### PR TITLE
Align with larger unicode symbols

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.4
+* Correctly align unicode in terminal
 
 1.3
 * Create cache directory in the remote eventuality that it doesn't exist

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 vasttrafik-cli (1.4-1) UNRELEASED; urgency=medium
 
   * New upstream release
+  * Depend on python3-wcwidth
 
  -- Salvo 'LtWorf' Tomaselli <tiposchi@tiscali.it>  Thu, 11 Nov 2021 13:00:00 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends:
     python3-typedload,
     python3-xtermcolor,
     python3-configobj,
+    python3-wcwidth,
     debhelper-compat (= 13),
     dh-sequence-python3
 Standards-Version: 4.6.0
@@ -22,6 +23,7 @@ Depends:
     ${python3:Depends},
     python3-typedload,
     python3-xtermcolor,
+    python3-wcwidth,
     python3-configobj
 Description: Public transport client, for Göteborg and the Västra Götaland county
  Västtrafik is the agency for public transport in Västra Götaland (Sweden).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 typedload
 xtermcolor
 configobj
+wcwidth

--- a/vasttrafik.py
+++ b/vasttrafik.py
@@ -27,6 +27,7 @@ from time import monotonic
 from typing import Dict, List, Optional, NamedTuple, Union
 from pathlib import Path
 
+from wcwidth import wcswidth as ulen  # type: ignore
 from typedload import load, dump
 from xtermcolor import colorize  # type: ignore
 
@@ -390,7 +391,7 @@ class Leg(NamedTuple):
 
         name += self.type.symbol
 
-        while len(name) < 33:
+        while ulen(name) < 33:
             name = ' ' + name
 
         if not color:
@@ -534,7 +535,7 @@ class BoardItem:
         if self.night:
             name += u"☾ "
 
-        while len(name) < 20:
+        while ulen(name) < 20:
             name = " " + name
 
         if not color:


### PR DESCRIPTION
Closes: #20 

Do correct alignment in the terminal even if wider unicode symbols are used.