### PR TITLE
Swap bg/fg colours

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.5
+* Fix background/foreground colour swapping
 
 1.4
 * Correctly align unicode in terminal

--- a/vasttrafik.py
+++ b/vasttrafik.py
@@ -397,8 +397,8 @@ class Leg(NamedTuple):
         if not color:
             return name
 
-        bgcolor = int('0x' + self.fgColor[1:], 16)
-        fgcolor = int('0x' + self.bgColor[1:], 16)
+        fgcolor = int('0x' + self.fgColor[1:], 16)
+        bgcolor = int('0x' + self.bgColor[1:], 16)
         return colorize(name, fgcolor, bg=bgcolor)
 
 
@@ -541,7 +541,7 @@ class BoardItem:
         if not color:
             return name
 
-        bgcolor = int('0x' + self.fgcolor[1:], 16)
-        fgcolor = int('0x' + self.bgcolor[1:], 16)
+        fgcolor = int('0x' + self.fgcolor[1:], 16)
+        bgcolor = int('0x' + self.bgcolor[1:], 16)
         return colorize(name, fgcolor, bg=bgcolor)
 


### PR DESCRIPTION
They were swapped in code, resulting in odd looking listings.

Since I've seen the issue in other implementations, I suspect that they were swapped in the values returned by the API and this was recently reverted.